### PR TITLE
Delay Jenkins authentication and continue negotiation if needed.

### DIFF
--- a/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/WindowsAuthForJenkins.java
+++ b/src/main/java/com/github/farmgeek4life/jenkins/negotiatesso/WindowsAuthForJenkins.java
@@ -77,7 +77,9 @@ public class WindowsAuthForJenkins extends WindowsAuthProviderImpl {
     @Override
     public IWindowsSecurityContext acceptSecurityToken(final String connectionId, final byte[] token, final String securityPackage) {
         IWindowsSecurityContext context = super.acceptSecurityToken(connectionId, token, securityPackage);
-        authenticateJenkins(context.getIdentity());
+        if (!context.isContinue()) {
+            authenticateJenkins(context.getIdentity());
+        }
         return context;
     }
     


### PR DESCRIPTION
User identity information might not be available if authentication mechanism needs to continue the negotiation, like in NTLM challenge/response authentication. Only try to authenticate when there's no continuation needed.

It should fix issue #7 